### PR TITLE
Prepare Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ _testmain.go
 *.test
 *.prof
 
-api-server-generator
+/api-server-generator
+/bin/
 
 /bindata.go
 
-/vendor
+/glide
+/vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+BINARY := api-server-generator
+SOURCES := $(find . -name '*.go' -type f | grep -v examples)
+
+LDFLAGS := -ldflags="-w"
+
+GLIDE_VERSION := 0.11.0
+
+DEFAULT_GOAL := bin/$(BINARY)
+
+bin/$(BINARY): $(SOURCES)
+	go generate
+	go build $(LDFLAGS) -o bin/$(BINARY)
+
+.PHONY: clean
+clean:
+	rm -fr bin/*
+
+.PHONY: deps
+deps: glide
+	go get github.com/jteeuwen/go-bindata/...
+	./glide install
+
+glide:
+ifeq ($(shell uname),Darwin)
+	curl -fL https://github.com/Masterminds/glide/releases/download/v$(GLIDE_VERSION)/glide-v$(GLIDE_VERSION)-darwin-amd64.zip -o glide.zip
+	unzip glide.zip
+	mv ./darwin-amd64/glide ./glide
+	rm -fr ./darwin-amd64
+	rm ./glide.zip
+else
+	curl -fL https://github.com/Masterminds/glide/releases/download/v$(GLIDE_VERSION)/glide-v$(GLIDE_VERSION)-linux-amd64.zip -o glide.zip
+	unzip glide.zip
+	mv ./linux-amd64/glide ./glide
+	rm -fr ./linux-amd64
+	rm ./glide.zip
+endif
+
+.PHONY: install
+install:
+	go generate
+	go install $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ Go 1.6 or higher is required.
 ### How to build
 
 ```bash
-# If you haven't installed go-bindata yet...
-$ go get -u github.com/jteeuwen/go-bindata/...
-
-# Please install glide beforehand.
-$ glide install
-
-$ go generate
-$ go build
+$ make deps
+$ make
 ```


### PR DESCRIPTION
## WHY
To install dependencies and build binaries easily and simply.

## WHAT
Write `Makefile` to integrate build process.