### PR TITLE
Rename application name to apig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BINARY := api-server-generator
+BINARY := apig
 SOURCES := $(find . -name '*.go' -type f | grep -v examples)
 
 LDFLAGS := -ldflags="-w"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# api-server-generator
+# apig: Golang RESTful API Server Generator
 
 ## Development
 

--- a/_examples/simple/controllers/user.go
+++ b/_examples/simple/controllers/user.go
@@ -3,8 +3,8 @@ package controllers
 import (
 	"net/http"
 
-	"github.com/wantedly/api-server-generator/examples/simple/db"
-	"github.com/wantedly/api-server-generator/examples/simple/models"
+	"github.com/wantedly/apig/_examples/simple/db"
+	"github.com/wantedly/apig/_examples/simple/models"
 
 	"github.com/gin-gonic/gin"
 )

--- a/_examples/simple/controllers/user_test.go
+++ b/_examples/simple/controllers/user_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http/httptest"
 	"strconv"
 
-	"github.com/wantedly/api-server-generator/examples/simple/db"
-	"github.com/wantedly/api-server-generator/examples/simple/models"
-	"github.com/wantedly/api-server-generator/examples/simple/server"
+	"github.com/wantedly/apig/_examples/simple/db"
+	"github.com/wantedly/apig/_examples/simple/models"
+	"github.com/wantedly/apig/_examples/simple/server"
 
 	"testing"
 )

--- a/_examples/simple/main.go
+++ b/_examples/simple/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/wantedly/api-server-generator/examples/simple/db"
-	"github.com/wantedly/api-server-generator/examples/simple/models"
-	"github.com/wantedly/api-server-generator/examples/simple/server"
+	"github.com/wantedly/apig/_examples/simple/db"
+	"github.com/wantedly/apig/_examples/simple/models"
+	"github.com/wantedly/apig/_examples/simple/server"
 )
 
 // main ...

--- a/_examples/simple/router/router.go
+++ b/_examples/simple/router/router.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"github.com/wantedly/api-server-generator/examples/simple/controllers"
+	"github.com/wantedly/apig/_examples/simple/controllers"
 
 	"github.com/gin-gonic/gin"
 )

--- a/_examples/simple/server/server.go
+++ b/_examples/simple/server/server.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"github.com/wantedly/api-server-generator/examples/simple/middleware"
-	"github.com/wantedly/api-server-generator/examples/simple/router"
+	"github.com/wantedly/apig/_examples/simple/middleware"
+	"github.com/wantedly/apig/_examples/simple/router"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: 1ebffdae872768989f74365de5bf7448190b94fc2e1d95fafb71b6f4f6cc0eda
-updated: 2016-07-08T11:25:58.701312975+09:00
+hash: 67e99e068c6b48e8392d049fa9989b0e1b3fe2b6a11b7d003a1fdd420f28930e
+updated: 2016-07-20T16:43:28.680533357+09:00
 imports:
 - name: github.com/gedex/inflector
   version: 91797f1712fd58f224781be1080b8613d096187e
+- name: github.com/tcnksm/go-gitconfig
+  version: 6411ba19847f20afe47f603328d97aaeca6def6f
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,3 @@
-package: github.com/wantedly/api-server-generator
+package: github.com/wantedly/apig
 import:
 - package: github.com/gedex/inflector


### PR DESCRIPTION
Close #5

## WHY
`api-server-generator` is too long to type.

## WHAT
Shorten the command and application name: `api-server-generator` -> `apig`

After merged this, we have to rename this repository name too.